### PR TITLE
[MMBotMDHacking] Fix a deadlock in Asm68kCommand

### DIFF
--- a/MMBotMDHacking/MDHackingModule.cs
+++ b/MMBotMDHacking/MDHackingModule.cs
@@ -13,14 +13,20 @@ namespace MMBotMDHacking
         void Asm68kCommand(IRC IrcObject, string channel, string user, string command)
         {
             ChangeDirectory();
-            File.WriteAllText("tmp.asm", '\t' + command);
-            Process asm68k = Process.Start(new ProcessStartInfo("asm68k.exe", "/k /p /o ae- tmp.asm, tmp.bin") { UseShellExecute = false, CreateNoWindow = true });
-            asm68k.WaitForExit();
-            if (File.Exists("tmp.bin"))
-                IrcObject.WriteMessage(Module1.BytesToString(File.ReadAllBytes("tmp.bin")), channel);
-            else
-                IrcObject.WriteMessage("Code could not be assembled!", channel);
-            RestoreDirectory();
+            try
+            {
+                File.WriteAllText("tmp.asm", '\t' + command);
+                Process asm68k = Process.Start(new ProcessStartInfo("asm68k.exe", "/k /p /o ae- tmp.asm, tmp.bin") { UseShellExecute = false, CreateNoWindow = true });
+                asm68k.WaitForExit();
+                if (File.Exists("tmp.bin"))
+                    IrcObject.WriteMessage(Module1.BytesToString(File.ReadAllBytes("tmp.bin")), channel);
+                else
+                    IrcObject.WriteMessage("Code could not be assembled!", channel);
+            }
+            finally
+            {
+                RestoreDirectory();
+            }
         }
 
         void VdpcalcCommand(IRC IrcObject, string channel, string user, string command)


### PR DESCRIPTION
The **ChangeDirectory()** method uses a monitor to avoid multiple threads from changing the current directory concurrently, and **RestoreDirectory()** releases the monitor. **Asm68kCommand** did not use a try-finally block to call **RestoreDirectory()**, so the lock could remain acquired if an exception is thrown before **RestoreDirectory()** is called.
